### PR TITLE
Clean up OpenLiberty/Microprofile test code

### DIFF
--- a/microservicetestcode/MicroProfile/pom.xml
+++ b/microservicetestcode/MicroProfile/pom.xml
@@ -23,26 +23,6 @@
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>1.1.1</version>
-        </dependency>
     </dependencies>
 
     <properties>
@@ -78,7 +58,7 @@
                     <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
                         <artifactId>openliberty-runtime</artifactId>
-                        <version>19.0.0.5</version>
+                        <version>19.0.0.8</version>
                         <type>zip</type>
                     </assemblyArtifact>
                     <serverName>sampleAppServer</serverName>

--- a/microservicetestcode/MicroProfile/src/main/liberty/config/server.xml
+++ b/microservicetestcode/MicroProfile/src/main/liberty/config/server.xml
@@ -1,11 +1,9 @@
 <server description="Sample Liberty server">
 
     <featureManager>
-        <feature>microProfile-2.1</feature>
+        <feature>jaxrs-2.1</feature>
         <feature>mpMetrics-1.1</feature>
     </featureManager>
-
-    <applicationManager autoExpand="true" />
 
     <mpMetrics authentication="false" />
 


### PR DESCRIPTION
Proposing a few changes which will improve OpenLiberty start time by ~30-40%
- Upgrade to OpenLiberty 19.0.0.8 which contains start time improvements
- Remove unneeded JAX-B libraries from application (make it a thin war)
- Only enable necessary features (JAX-RS and MP Metrics) instead of all MP features